### PR TITLE
Fix/weaponsforge 20

### DIFF
--- a/client/src/common/ui/loadingbutton/index.js
+++ b/client/src/common/ui/loadingbutton/index.js
@@ -19,7 +19,7 @@ function LoadingButton ({
         {(isloading)
           ? <CircularProgress
             size={24}
-            color={globalState.activeTheme === 'light' ? 'dark' : 'main'}
+            color={globalState.activeTheme === 'light' ? 'dark' : 'primary'}
           />
           : <span>
             {label}


### PR DESCRIPTION
- Follow-up for PR [#79](https://github.com/weaponsforge/my-phonebook/pull/79): Fix the missing `main` color object on dark theme. Use `primary`.