### PR TITLE
Feature/weaponsforge 50

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - dev
+      - feature/weaponsforge-50
 
 jobs:
   lint-export-client:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - dev
-      - feature/weaponsforge-50
 
 jobs:
   lint-export-client:

--- a/client/.firebaserc
+++ b/client/.firebaserc
@@ -8,6 +8,11 @@
         "dev": [
           "myphonebook-app-dev"
         ]
+      },
+      "storage": {
+        "dev": [
+          "myphonebook-app-dev.appspot.com"
+        ]
       }
     }
   },

--- a/client/README.md
+++ b/client/README.md
@@ -53,6 +53,12 @@ The following dependecies are used for this project. Feel free to experiment usi
    | NEXT_PUBLIC_MEDIA_BG1                        | Firebase storage download URL of the hi-resolution asset file "loginBgResized.jpg"                                                                                                                                                                                                                                                                       |
    | NEXT_PUBLIC_RANDOM_JOKE_API                  | Access URL to the JokeAPI, a REST API that serves uniformly and well formatted jokes.                                                                                                                                                                                                                                                                    |
 
+4. Deploy the Firestore Security Rules defined in the "firestore.rules" file using the Firebase CLI.<br>
+`firebase deploy --only firestore:rules`
+
+5. Deploy the Firebase Storage Security Rules defined in the "storage.rules" file using the Firebase CLI.<br>
+`firebase deploy --only storage:dev`
+
 ## Usage
 
 1. Run the project in development mode:<br>

--- a/client/firebase.json
+++ b/client/firebase.json
@@ -1,4 +1,11 @@
 {
+  "firestore": {
+    "rules": "firestore.rules"
+  },
+  "storage": {
+    "rules": "storage.rules",
+    "target": "dev"
+  },
   "hosting": [{
     "target": "dev",
     "public": "out",

--- a/client/firestore.rules
+++ b/client/firestore.rules
@@ -107,6 +107,7 @@ service cloud.firestore {
         'first_name',
         'last_name',
         'middle_name',
+        'email_address',
         'phone_number',
         'date_updated'
       ];
@@ -117,7 +118,7 @@ service cloud.firestore {
         	['date_updated'])) &&
         // Does not allow updating the following fields
       	(!request.resource.data.diff(resource.data).affectedKeys().hasAny(
-          ['doc_id', 'date_created', 'email_address'])) &&
+          ['doc_id', 'date_created'])) &&
         // Only allows updates for the following fields
       	(request.resource.data.diff(resource.data).affectedKeys().hasOnly(fields))
     }
@@ -137,7 +138,8 @@ service cloud.firestore {
       allow update: if isValidUser() && isAccountOwner(userId) &&
       	isValidUpdateUserFields() &&
         validContactFieldType(request.resource.data) &&
-        validContactFieldLength(request.resource.data);
+        validContactFieldLength(request.resource.data) &&
+        validContactField(request.resource.data);
       allow get: if isValidUser() && isAccountOwner(userId);
       allow list: if false;
     }

--- a/client/firestore.rules
+++ b/client/firestore.rules
@@ -2,6 +2,8 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
+  	// AUTH --------------------------------------------------------
+
     // Is the user signed-in using basic authentication?
     function isSignedIn() {
       return request.auth != null;
@@ -18,6 +20,8 @@ service cloud.firestore {
       return request.auth.uid == userId;
     }
 
+    // CONTACTS --------------------------------------------------------
+
     // Check for valid Contact field types
     function validContactFieldType (requestData) {
     	return
@@ -28,6 +32,7 @@ service cloud.firestore {
         (!('middle_name' in requestData.keys()) || requestData.middle_name is string) &&
         (!('phone_number' in requestData.keys()) || requestData.phone_number is string) &&
         (!('profile_picture_url' in requestData.keys()) || requestData.profile_picture_url is string) &&
+        (!('sorting' in requestData.keys()) || requestData.sorting is string) &&
         (!('date_created' in requestData.keys()) || requestData.date_created is timestamp) &&
         (!('date_updated' in requestData.keys()) || requestData.date_updated is timestamp);
     }
@@ -40,11 +45,18 @@ service cloud.firestore {
         (!('last_name' in requestData.keys()) || requestData.last_name.size() < 50) &&
         (!('middle_name' in requestData.keys()) || requestData.middle_name.size() < 50) &&
         (!('phone_number' in requestData.keys()) || requestData.phone_number.size() < 20) &&
-        (!('profile_picture_url' in requestData.keys()) || requestData.profile_picture_url.size() < 600);
+        (!('profile_picture_url' in requestData.keys()) || requestData.profile_picture_url.size() < 600) &&
+        (!('sorting' in requestData.keys()) || requestData.phone_number.size() < 200);
+    }
+
+    // Check if Contact fields satisfies other requirements
+    function validContactField (requestData) {
+    	return
+      	(!('email_address' in requestData.keys()) || requestData.email_address.matches('.*@.*[.].*'))
     }
 
     // New Contact documents should contain only the specified keys
-    function validNewContact () {
+    function isValidNewContact () {
     	let fields = [
       	'doc_id',
         'email_address',
@@ -53,6 +65,7 @@ service cloud.firestore {
         'middle_name',
         'phone_number',
         'profile_picture_url',
+        'sorting',
         'date_created',
         'date_updated'
       ];
@@ -62,7 +75,7 @@ service cloud.firestore {
        	(request.resource.data.keys().hasOnly(fields));
     }
 
-    // Contact for update should only contain all (or any) of the specified keys
+    // Contact documents for updating should contain only the specified keys
     function isValidUpdateContactFields () {
       let fields = [
         'email_address',
@@ -71,6 +84,7 @@ service cloud.firestore {
         'middle_name',
         'phone_number',
         'profile_picture_url',
+        'sorting',
         'date_updated'
       ];
 
@@ -85,6 +99,31 @@ service cloud.firestore {
       	(request.resource.data.diff(resource.data).affectedKeys().hasOnly(fields))
     }
 
+    // USER PROFILE --------------------------------------------------------
+
+    // User profile for update should only contain all (or any) of the specified keys
+    function isValidUpdateUserFields () {
+      let fields = [
+        'first_name',
+        'last_name',
+        'middle_name',
+        'phone_number',
+        'date_updated'
+      ];
+
+    	return
+      	// Contains required field
+        (request.resource.data.diff(resource.data).affectedKeys().hasAll(
+        	['date_updated'])) &&
+        // Does not allow updating the following fields
+      	(!request.resource.data.diff(resource.data).affectedKeys().hasAny(
+          ['doc_id', 'date_created', 'email_address'])) &&
+        // Only allows updates for the following fields
+      	(request.resource.data.diff(resource.data).affectedKeys().hasOnly(fields))
+    }
+
+    // DOCUMENTS matching rules  --------------------------------------------------------
+
     // Block read/write access on all paths from the root level
     match /{document=**} {
     	allow read, write: if false;
@@ -93,8 +132,12 @@ service cloud.firestore {
 		// Authenticated users can read, create and update only their own user document
     // under the /users root-collection only
     match /users/{userId}  {
+    	// New user documents are created from the backend after email verification
     	allow create, delete: if false;
-      allow update: if isValidUser() && isAccountOwner(userId);
+      allow update: if isValidUser() && isAccountOwner(userId) &&
+      	isValidUpdateUserFields() &&
+        validContactFieldType(request.resource.data) &&
+        validContactFieldLength(request.resource.data);
       allow get: if isValidUser() && isAccountOwner(userId);
       allow list: if false;
     }
@@ -110,12 +153,15 @@ service cloud.firestore {
 		// users/{userId}/posts subcollection
     match /users/{userId}/contacts/{contactId} {
     	allow create: if isValidUser() && isAccountOwner(userId) &&
-      	validNewContact() &&
-        validContactFieldType(request.resource.data);
+      	isValidNewContact() &&
+        validContactFieldType(request.resource.data) &&
+        validContactFieldLength(request.resource.data) &&
+        validContactField(request.resource.data);
       allow update: if isValidUser() && isAccountOwner(userId) &&
       	isValidUpdateContactFields() &&
         validContactFieldType(request.resource.data) &&
-        validContactFieldLength(request.resource.data);
+        validContactFieldLength(request.resource.data) &&
+        validContactField(request.resource.data);
       allow delete: if isValidUser() && isAccountOwner(userId);
       allow get: if isValidUser() && isAccountOwner(userId);
       allow list: if isValidUser() && isAccountOwner(userId);

--- a/client/firestore.rules
+++ b/client/firestore.rules
@@ -18,6 +18,25 @@ service cloud.firestore {
       return request.auth.uid == userId;
     }
 
+    // New Contact documents should contain only the specified keys
+    function validNewContact () {
+     	return request.resource.data.keys().hasOnly(['doc_id', 'name', 'location', 'city', 'address', 'hours', 'cuisine', 'date_created', 'date_updated']);
+    }
+
+    // Contact for update should only contain all (or any) of the specified keys
+    function isValidUpdateContactFields () {
+    	return
+      	// Contains required field
+        (request.resource.data.diff(resource.data).affectedKeys().hasAll(
+        	['date_updated'])) &&
+        // Does not allow updating the following fields
+      	(!request.resource.data.diff(resource.data).affectedKeys().hasAny(
+          ['doc_id', 'date_created'])) &&
+        // Only allows updates for the following fields
+      	(request.resource.data.diff(resource.data).affectedKeys().hasOnly(
+        	['name', 'location', 'city', 'address', 'hours', 'cuisine', 'date_updated']))
+    }
+
     // Block read/write access on all paths from the root level
     match /{document=**} {
     	allow read, write: if false;
@@ -40,9 +59,11 @@ service cloud.firestore {
     }
 
 		// Only authenticated users can read, create and update documents under the
-		// users/{userId}/cards subcollection
+		// users/{userId}/posts subcollection
     match /users/{userId}/contacts/{contactId} {
-      allow write: if isValidUser() && isAccountOwner(userId);
+    	allow create: if isValidUser() && isAccountOwner(userId) && validNewContact();
+      allow update: if isValidUser() && isAccountOwner(userId) && isValidUpdateContactFields();
+      allow delete: if isValidUser() && isAccountOwner(userId);
       allow get: if isValidUser() && isAccountOwner(userId);
       allow list: if isValidUser() && isAccountOwner(userId);
     }

--- a/client/firestore.rules
+++ b/client/firestore.rules
@@ -18,13 +18,62 @@ service cloud.firestore {
       return request.auth.uid == userId;
     }
 
+    // Check for valid Contact field types
+    function validContactFieldType (requestData) {
+    	return
+      	(!('doc_id' in requestData.keys()) || requestData.doc_id is string) &&
+      	(!('email_address' in requestData.keys()) || requestData.email_address is string) &&
+        (!('first_name' in requestData.keys()) || requestData.first_name is string) &&
+        (!('last_name' in requestData.keys()) || requestData.last_name is string) &&
+        (!('middle_name' in requestData.keys()) || requestData.middle_name is string) &&
+        (!('phone_number' in requestData.keys()) || requestData.phone_number is string) &&
+        (!('profile_picture_url' in requestData.keys()) || requestData.profile_picture_url is string) &&
+        (!('date_created' in requestData.keys()) || requestData.date_created is timestamp) &&
+        (!('date_updated' in requestData.keys()) || requestData.date_updated is timestamp);
+    }
+
+    // Check for Contact fields required character length
+    function validContactFieldLength (requestData) {
+    	return
+      	(!('email_address' in requestData.keys()) || requestData.email_address.size() < 50) &&
+        (!('first_name' in requestData.keys()) || requestData.first_name.size() < 50) &&
+        (!('last_name' in requestData.keys()) || requestData.last_name.size() < 50) &&
+        (!('middle_name' in requestData.keys()) || requestData.middle_name.size() < 50) &&
+        (!('phone_number' in requestData.keys()) || requestData.phone_number.size() < 20) &&
+        (!('profile_picture_url' in requestData.keys()) || requestData.profile_picture_url.size() < 600);
+    }
+
     // New Contact documents should contain only the specified keys
     function validNewContact () {
-     	return request.resource.data.keys().hasOnly(['doc_id', 'name', 'location', 'city', 'address', 'hours', 'cuisine', 'date_created', 'date_updated']);
+    	let fields = [
+      	'doc_id',
+        'email_address',
+        'first_name',
+        'last_name',
+        'middle_name',
+        'phone_number',
+        'profile_picture_url',
+        'date_created',
+        'date_updated'
+      ];
+
+    	return
+      	(request.resource.data.keys().hasAll(fields)) &&
+       	(request.resource.data.keys().hasOnly(fields));
     }
 
     // Contact for update should only contain all (or any) of the specified keys
     function isValidUpdateContactFields () {
+      let fields = [
+        'email_address',
+        'first_name',
+        'last_name',
+        'middle_name',
+        'phone_number',
+        'profile_picture_url',
+        'date_updated'
+      ];
+
     	return
       	// Contains required field
         (request.resource.data.diff(resource.data).affectedKeys().hasAll(
@@ -33,8 +82,7 @@ service cloud.firestore {
       	(!request.resource.data.diff(resource.data).affectedKeys().hasAny(
           ['doc_id', 'date_created'])) &&
         // Only allows updates for the following fields
-      	(request.resource.data.diff(resource.data).affectedKeys().hasOnly(
-        	['name', 'location', 'city', 'address', 'hours', 'cuisine', 'date_updated']))
+      	(request.resource.data.diff(resource.data).affectedKeys().hasOnly(fields))
     }
 
     // Block read/write access on all paths from the root level
@@ -61,8 +109,13 @@ service cloud.firestore {
 		// Only authenticated users can read, create and update documents under the
 		// users/{userId}/posts subcollection
     match /users/{userId}/contacts/{contactId} {
-    	allow create: if isValidUser() && isAccountOwner(userId) && validNewContact();
-      allow update: if isValidUser() && isAccountOwner(userId) && isValidUpdateContactFields();
+    	allow create: if isValidUser() && isAccountOwner(userId) &&
+      	validNewContact() &&
+        validContactFieldType(request.resource.data);
+      allow update: if isValidUser() && isAccountOwner(userId) &&
+      	isValidUpdateContactFields() &&
+        validContactFieldType(request.resource.data) &&
+        validContactFieldLength(request.resource.data);
       allow delete: if isValidUser() && isAccountOwner(userId);
       allow get: if isValidUser() && isAccountOwner(userId);
       allow list: if isValidUser() && isAccountOwner(userId);

--- a/client/firestore.rules
+++ b/client/firestore.rules
@@ -1,0 +1,50 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // Is the user signed-in using basic authentication?
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    // Is the signed-in user a valid App user?
+    // Has a custom claims "account_level" value: 1=admin, 2=user
+    function isValidUser() {
+      return isSignedIn() && request.auth.token.account_level != null
+    }
+
+    // Does the signed-in user's auth uid match the requested userId?
+    function isAccountOwner(userId) {
+      return request.auth.uid == userId;
+    }
+
+    // Block read/write access on all paths from the root level
+    match /{document=**} {
+    	allow read, write: if false;
+    }
+
+		// Authenticated users can read, create and update only their own user document
+    // under the /users root-collection only
+    match /users/{userId}  {
+    	allow create, delete: if false;
+      allow update: if isValidUser() && isAccountOwner(userId);
+      allow get: if isValidUser() && isAccountOwner(userId);
+      allow list: if false;
+    }
+
+		// Authenticated users can read only their own subcollections under /users/{userId}
+    // Unauthenticated users cannot write in any subcollections under /users/{userId}
+    match /users/{userId}/{document=**} {
+      allow write: if false;
+      allow list: if isValidUser() && isAccountOwner(userId);
+    }
+
+		// Only authenticated users can read, create and update documents under the
+		// users/{userId}/cards subcollection
+    match /users/{userId}/contacts/{contactId} {
+      allow write: if isValidUser() && isAccountOwner(userId);
+      allow get: if isValidUser() && isAccountOwner(userId);
+      allow list: if isValidUser() && isAccountOwner(userId);
+    }
+  }
+}

--- a/client/firestore.rules
+++ b/client/firestore.rules
@@ -2,7 +2,7 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-  	// AUTH --------------------------------------------------------
+    // AUTH --------------------------------------------------------
 
     // Is the user signed-in using basic authentication?
     function isSignedIn() {
@@ -91,7 +91,7 @@ service cloud.firestore {
     	return
       	// Contains required field
         (request.resource.data.diff(resource.data).affectedKeys().hasAll(
-        	['date_updated'])) &&
+          ['date_updated'])) &&
         // Does not allow updating the following fields
       	(!request.resource.data.diff(resource.data).affectedKeys().hasAny(
           ['doc_id', 'date_created'])) &&
@@ -115,7 +115,7 @@ service cloud.firestore {
     	return
       	// Contains required field
         (request.resource.data.diff(resource.data).affectedKeys().hasAll(
-        	['date_updated'])) &&
+          ['date_updated'])) &&
         // Does not allow updating the following fields
       	(!request.resource.data.diff(resource.data).affectedKeys().hasAny(
           ['doc_id', 'date_created'])) &&
@@ -127,14 +127,14 @@ service cloud.firestore {
 
     // Block read/write access on all paths from the root level
     match /{document=**} {
-    	allow read, write: if false;
+      allow read, write: if false;
     }
 
-		// Authenticated users can read, create and update only their own user document
+    // Authenticated users can read, create and update only their own user document
     // under the /users root-collection only
     match /users/{userId}  {
-    	// New user documents are created from the backend after email verification
-    	allow create, delete: if false;
+      // New user documents are created from the backend after email verification
+      allow create, delete: if false;
       allow update: if isValidUser() && isAccountOwner(userId) &&
       	isValidUpdateUserFields() &&
         validContactFieldType(request.resource.data) &&
@@ -144,15 +144,15 @@ service cloud.firestore {
       allow list: if false;
     }
 
-		// Authenticated users can read only their own subcollections under /users/{userId}
+    // Authenticated users can read only their own subcollections under /users/{userId}
     // Unauthenticated users cannot write in any subcollections under /users/{userId}
     match /users/{userId}/{document=**} {
       allow write: if false;
       allow list: if isValidUser() && isAccountOwner(userId);
     }
 
-		// Only authenticated users can read, create and update documents under the
-		// users/{userId}/posts subcollection
+    // Only authenticated users can read, create and update documents under the
+    // users/{userId}/posts subcollection
     match /users/{userId}/contacts/{contactId} {
     	allow create: if isValidUser() && isAccountOwner(userId) &&
       	isValidNewContact() &&

--- a/client/storage.rules
+++ b/client/storage.rules
@@ -12,11 +12,6 @@ service firebase.storage {
       return isSignedIn() && request.auth.token.account_level != null
     }
 
-    // Does the signed-in user's auth uid match the requested userId?
-    function isAccountOwner(userId) {
-      return request.auth.uid == userId;
-    }
-
     match /{allPaths=**} {
       allow read;
       allow write: if isValidUser();

--- a/client/storage.rules
+++ b/client/storage.rules
@@ -1,0 +1,25 @@
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    // Is the user signed-in using basic authentication?
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    // Is the signed-in user a valid App user?
+    // Has a custom claims "account_level" value: 1=admin, 2=user
+    function isValidUser() {
+      return isSignedIn() && request.auth.token.account_level != null
+    }
+
+    // Does the signed-in user's auth uid match the requested userId?
+    function isAccountOwner(userId) {
+      return request.auth.uid == userId;
+    }
+
+    match /{allPaths=**} {
+      allow read;
+      allow write: if isValidUser();
+    }
+  }
+}

--- a/server/src/modules/user/createuser.js
+++ b/server/src/modules/user/createuser.js
@@ -23,7 +23,7 @@ const createUser = async (userId, params) => {
         first_name: params?.first_name ?? '',
         middle_name: params?.middle_name ?? '',
         last_name: params?.last_name ?? '',
-        email: params?.email ?? '',
+        email_address: params?.email ?? '',
         phone_number: params?.phone_number ?? '',
         date_created: admin.firestore.Timestamp.now(),
         date_updated: admin.firestore.Timestamp.now()


### PR DESCRIPTION
- Strict Firestore Security Rules for Issue [#50](https://github.com/weaponsforge/my-phonebook/issues/50)  
- Minimal Firebase Storage Security Rules for Issue [#51](https://github.com/weaponsforge/my-phonebook/issues/51)

### Firestore Security Rules Summary

- Allow **writing** (create, update, delete) documents under the `users` root-level collection only
   - success: `/users/{userId}`
   - fail: `/mycollection/{docId}`

- Allow **writing** (create, update, delete) of only uid-named documents under the `/users` root collection
   - success: `/users/{userId}`
   - fail: `/users/mydocument`

- Allow **writing** (create, update, delete) documents in allowed subcollections only. Currently, only the `users/{userId}/contacts` subcollection is allowed to contain documents
   - success: `/users/{userId}/contacts/{docId}`
   - fail: `/users/{userId}/tickets/{docId}`

- Allow **reading** documents only when a user is signed-in, the user has an `request.auth.account_level` key and the requested document falls under (or is) a `/{userId}` document
   - success (requires sign-in): `/users/{userId}/contacts/{docId}`, `/users/{userId}`

- Disable **creating** new subcollections under documents in `users/{userId}/contacts/{docId}`
   - Creating subcollections under a document in a subcollection is disabled by default
   - fail (creating mysubcollection): `/users/{userId}/contacts/{docId}/mysubcollection/{newId}`

### Create New Contact Document Rules

The following fields and their field type and character lengths are required when creating a new Contact under `/users/{userId}/contacts/{docId}`. Adding extra fields will cause the Contact document creation to fail.

| Field | Type | Length |
| --- | --- | --- |
| doc_id | string | 50 |
| email_address | string | 50 |
| first_name | string | 50 |
| last_name | string | 50 |
| middle_name | string | 50 |
| phone_number | string | 50 |
| profile_picture_url | string | 600 |
| sorting | string | 200 |
| date_created | Firestore Timestamp | - |
| date_updated | Firestore Timestamp | - |

### Update Contact Document Rules

The following fields and their field type and character lengths are required when updating an existing Contact under `/users/{userId}/contacts/{docId}. Adding extra fields will also cause the Contact document update to fail. 

Provide the Required fields and do not supply the Not Allowed fields when updating a Contact. One or more Optional fields may be set for update.

#### Required

| Field | Type | Length |
| --- | --- | --- |
| date_updated | Firestore Timestamp | - |

#### Not Allowed

| Field | Type | Length |
| --- | --- | --- |
| doc_id | string | 50 |
| date_created | Firestore Timestamp | - |

#### Optional

| Field | Type | Length |
| --- | --- | --- |
| email_address | string | 50 |
| first_name | string | 50 |
| last_name | string | 50 |
| middle_name | string | 50 |
| phone_number | string | 50 |
| profile_picture_url | string | 600 |
| sorting | string | 200 |

---

### Update User Profile Document Rules

The following fields and their field type and character lengths are required when updating an existing User profile document in `/users/{userId}`. Adding extra fields will also cause the document update to fail. 

Provide the Required fields and do not supply the Not Allowed fields when updating a User profile document. One or more Optional fields may be set for update.

#### Required

| Field | Type | Length |
| --- | --- | --- |
| date_updated | Firestore Timestamp | - |

#### Not Allowed

| Field | Type | Length |
| --- | --- | --- |
| doc_id | string | 50 |
| date_created | Firestore Timestamp | - |

#### Optional

| Field | Type | Length |
| --- | --- | --- |
| email_address | string | 50 |
| first_name | string | 50 |
| last_name | string | 50 |
| middle_name | string | 50 |
| phone_number | string | 50 |
